### PR TITLE
Fix some settings in the application

### DIFF
--- a/bin/svn-bisect
+++ b/bin/svn-bisect
@@ -3,6 +3,9 @@
 use strict;
 use warnings;
 
+use FindBin;
+use lib "$FindBin::RealBin/../lib";
+
 use App::SVN::Bisect;
 use Getopt::Long qw(:config require_order);
 

--- a/bin/svn-bisect
+++ b/bin/svn-bisect
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Copyright (C) 2008-2009, Mark Glines.  See "LICENSE".
 use strict;
 use warnings;


### PR DESCRIPTION
I made two minor modifications to make the application easier to use:

1. Modified the hash-bang line to get perl from /usr/bin/env.  This helps on platforms (e.g., Mac), where perl may not be in the standard location.
2. Updated `@INC` using `FindBin`.  Previously, unless the `lib/` directory for this program was in `@INC`, it couldn't find its own library files.